### PR TITLE
Simplified instance parameters

### DIFF
--- a/lib/rets.js
+++ b/lib/rets.js
@@ -54,41 +54,59 @@ var Session      = require('./session');
  * @throws {Error} If an invalid URL object or string is passed.
  */
 util.inherits(RETS, EventEmitter);
-function RETS(options) {
+function RETS(config, options) {
 
     /**
      * @todo Document this pattern.
      */
     if (!(this instanceof RETS)) {
-        return new RETS(options);
+        return new RETS(config, options);
     }
 
     /**
-     * Holds the original options passed by the user.
-     *
-     * @member {object|string}
+     * If config is a string, the user passed a url so move it into config.url
+     * as a parsed url.
      */
-    this.options = options;
+    if (typeof config === 'string') {
+        config = {url: url.parse(config)};
+    }
 
-    if (typeof this.options === 'undefined') {
-        throw new Error('options is required.');
+    /**
+     * If config is not an object, throw an error.
+     */
+    if (typeof config !== 'object') {
+        throw new Error('config is required and must be a string or an object.');
     }
-    if (typeof this.options.url === 'undefined') {
-        throw new Error('options.url is required.');
+
+    /**
+     * If config is not an object, throw an error.
+     */
+    if (typeof config.url === 'string') {
+        config.url = url.parse(config.url);
     }
-    if (typeof this.options.url !== 'string' && typeof this.options.url !== 'object') {
-        throw new Error('options.url is not a string or an object.');
+
+    /**
+     * If config.url.auth is not null, parse it to extract the user and
+     * password and assign these to config.user and config.pass respectively.
+     */
+    if (config.url.auth !== null) {
+        var auth = config.url.auth.split(':');
+        config.user = auth[0];
+        if (auth.length > 1) {
+            config.pass = auth[1];
+        }
     }
-    if (typeof this.options.url === 'string') {
-        this.url = this.options.url = url.parse(this.options.url);
-    } else {
-        this.url = this.options.url;
+
+    /**
+     * If by now config.host is null, throw an error as we need at least that
+     * to connect to a rets server.
+     */
+    if (config.url.host === null) {
+        throw Error("config.url.host is not valid");
     }
-    if (typeof this.url.host !== 'string' || this.url.host.length < 1) {
-        throw new Error('invalid options.url.host.');
-    }
-    if (typeof this.url.auth !== 'string' || this.url.auth.length < 2 || this.url.auth.indexOf(':') < 0 ) {
-        throw new Error('invalid options.url.auth.');
+
+    if (config.user === null) {
+        throw Error("config.user is required");
     }
 
     /**
@@ -102,20 +120,30 @@ function RETS(options) {
      */
     this.defaults = {
         url: null,
+        user: null,
+        pass: null,
         ua: {
-            name: 'RETS-Connector1/2',
-            pass: ''
+            name: 'RETS.JS@0.0.1',
+            pass: null
         },
         version: 'RETS/1.7.2'
     };
 
     /**
-     * Holds the final configuration for the instance
-     * after processing, defaults, validation, etc.
+     * Holds the original options passed by the user.
+     *
+     * @member {object|string}
      */
-    this.config = {};
-    util._extend(this.config, this.defaults);
-    util._extend(this.config, this.options);
+    this.options = options || {};
+
+    /**
+     * Holds the original options passed by the user.
+     *
+     * @member {object|string}
+     */
+    this.config = extend(true, {}, this.defaults, config, this.options);
+
+    // debug("config: \n%s", util.inspect(this.config, {colors:true}));
 
     /**
      * Hold reference to Session instance.

--- a/lib/rets.js
+++ b/lib/rets.js
@@ -18,6 +18,7 @@ var path         = require('path');
 var os           = require('os');
 var fs           = require('fs');
 var util         = require('util');
+var extend       = require('extend');
 var url          = require('url');
 var EventEmitter = require('events').EventEmitter;
 var xml          = require('xml2js').parseString;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "MD5": "^1.2.1",
     "cli-table": "^0.3.1",
     "event-stream": "^3.3.0",
+    "extend": "^2.0.1",
     "inflected": "^1.1.6",
     "lodash": "^3.5.0",
     "request": "^2.53.0",

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -31,7 +31,7 @@ module.exports = describe('RETS', function(){
         assert.equal(typeof RETS, 'function');
     });
 
-    it('Instantiates correctly.', function(){
+    it('Accepts a URL string with embeded auth credentials.', function(){
         assert(instance instanceof RETS);
     });
 

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -16,7 +16,7 @@ module.exports = describe('RETS', function(){
     });
 
     beforeEach('Create new instance before each test.', function(){
-        instance = RETS(config);
+        instance = RETS("http://user:pass@rets.server.com:9160/Login.asmx/Login");
     });
 
     afterEach('Clear instance after each test.', function(){

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -5,7 +5,6 @@ module.exports = describe('RETS', function(){
 
     var RETS = null;
     var instance = null;
-    var config = require('./servers/config.json')[0];
 
     before('Load RETS', function() {
         RETS = require('../');

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -39,35 +39,56 @@ module.exports = describe('RETS', function(){
         assert.throws(function(){
             new RETS("http://rets.server.com:9160/Login.asmx/Login");
         }, Error);
-
-    it('Throws an error if options.url is undefined.', function(){
         assert.throws(function(){
-            new RETS({});
+            new RETS("http://rets.server.com:9160/Login.asmx/Login", {
+                pass: 'opts_pass'
+            });
         }, Error);
     });
 
-    it('Throws an error if options.url is not a string or object.', function(){
+    it('Accepts a URL string and an options object.', function(){
+        var instance = RETS("http://user:pass@rets.server.com:9160/Login.asmx/Login", {
+            user: 'opts_user',
+            pass: 'opts_pass'
+        });
+        assert(instance instanceof RETS);
+    });
+
+    it('Accepts an object as the only parameter.', function(){
+        var instance = RETS({
+            url: "http://user:pass@rets.server.com:9160/Login.asmx/Login"
+        });
+        assert(instance instanceof RETS);
+    });
+
+    it('options.user overrides URL-embedded user.', function(){
+        var instance = RETS("http://user:pass@rets.server.com:9160/Login.asmx/Login", {
+            user: 'opts_user'
+        });
+        assert.equal(instance.config.user, 'opts_user');
+    });
+
+    it('options.pass overrides URL-embedded password.', function(){
+        var instance = RETS("http://user:pass@rets.server.com:9160/Login.asmx/Login", {
+            pass: 'opts_pass'
+        });
+        assert.equal(instance.config.pass, 'opts_pass');
+    });
+
+    it('Instantiates correctly.', function(){
+        assert(instance instanceof RETS);
+    });
+
+    it('Throws an error if no parameters are passed when instantiating.', function(){
         assert.throws(function(){
-            new RETS({url:true});
+            new RETS();
         }, Error);
     });
 
-    it('Throws an error if options.url is not a valid url.', function(){
+    it('Throws an error if URL is not a valid.', function(){
         assert.throws(function(){
-            new RETS({url:"some invalid url"});
+            new RETS("some invalid url");
         }, Error);
-    });
-
-    it('Throws an error if options.url does not have credentials.', function(){
-        assert.throws(function(){
-            new RETS({url:"http://localhost:9160/mock/Login"});
-        }, Error);
-    });
-
-    it('Accepts an object as options.', function(){
-        assert.equal(instance.config.url, config.url);
-        assert.equal(instance.config.ua.name, config.ua.name);
-        assert.equal(instance.config.ua.pass, config.ua.pass);
     });
 
     it('Has a login method.', function(){

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -8,7 +8,7 @@ module.exports = describe('RETS', function(){
     var config = require('./servers/config.json')[0];
 
     before('Load RETS', function() {
-        RETS = require('../lib/rets');
+        RETS = require('../');
     });
 
     after('Clanup after all tests.', function(){

--- a/test/rets.test.js
+++ b/test/rets.test.js
@@ -35,11 +35,10 @@ module.exports = describe('RETS', function(){
         assert(instance instanceof RETS);
     });
 
-    it('Throws an error if options is undefined.', function(){
+    it('Throws if instantiation attempted without user name (URL-embedded or as option).', function(){
         assert.throws(function(){
-            new RETS();
+            new RETS("http://rets.server.com:9160/Login.asmx/Login");
         }, Error);
-    });
 
     it('Throws an error if options.url is undefined.', function(){
         assert.throws(function(){


### PR DESCRIPTION
This change makes it possible to instantiate RETS by passing a URL string OR an object. Optionally, one can now pass an object with options as a second parameter to override defaults and change behavior as outlined below:

`var rets = new RETS(url<string|object>[, options<object>]);`

* `url` as string can be simply a URL without embedded credentials or you can include credentials. If not embedded, at least the user name must be passed in the options object.
* `url` as object must inclue at least a url member (ie: `url.url`).
* `options.url` the url string
* `options.user` to override the user name.
* `options.pass` the password.
* `options.ua` user agent object.
* `options.ua.name` user agent name.
* `options.ua.pass` user agent password.
